### PR TITLE
Dereference editor from DOM node (#5654)

### DIFF
--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -368,12 +368,14 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.createNodeViews()
     this.prependClass()
 
-    // Let’s store the editor instance in the DOM element.
-    // So we’ll have access to it for tests.
-    // @ts-ignore
-    const dom = this.view.dom as TiptapEditorHTMLElement
+    if (typeof window !== 'undefined' && window.Cypress) {
+      // Let’s store the editor instance in the DOM element.
+      // So we’ll have access to it for tests.
+      // @ts-ignore
+      const dom = this.view.dom as TiptapEditorHTMLElement
 
-    dom.editor = this
+      dom.editor = this
+    }
   }
 
   /**
@@ -568,13 +570,6 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.emit('destroy')
 
     if (this.view) {
-      // Cleanup our test reference to prevent memory leaks
-      // @ts-ignore
-      const dom = this.view.dom as TiptapEditorHTMLElement
-      if (dom && dom.editor) {
-        delete dom.editor;
-      }
-
       this.view.destroy()
     }
 

--- a/packages/core/src/Editor.ts
+++ b/packages/core/src/Editor.ts
@@ -568,6 +568,13 @@ export class Editor extends EventEmitter<EditorEvents> {
     this.emit('destroy')
 
     if (this.view) {
+      // Cleanup our test reference to prevent memory leaks
+      // @ts-ignore
+      const dom = this.view.dom as TiptapEditorHTMLElement
+      if (dom && dom.editor) {
+        delete dom.editor;
+      }
+
       this.view.destroy()
     }
 


### PR DESCRIPTION
## Changes Overview
Delete the reference to the editor from the DOM node.

## Implementation Approach
Safely delete

## Testing Done
Tested on my local branch (see #5654 for repro steps).

## Verification Steps
Pull down changes and attempt repro steps.

## Additional Notes
N/A

## Checklist
- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues
#5654
